### PR TITLE
add bump github actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,22 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: Bump version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
## Overview
This PR adds a GitHub Actions workflow for automated version management and release creation.

## Changes
- Add 
  - Automatically runs on pushes to the main branch
  - Uses  to automatically bump version and create tags
  - Uses  to create GitHub releases automatically

## Expected Behavior
1. Version is automatically bumped when merged into main branch
2. New tag is created
3. GitHub release is automatically created with changelog