### PR TITLE
Fix PHP Notice in TestSuite HTML Reporter for output buffer handling

### DIFF
--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -143,7 +143,9 @@ class CakeHtmlReporter extends CakeBaseReporter {
  */
 	public function paintFooter($result) {
 		echo $this->_buffer;
-		ob_end_flush();
+		if (ob_get_length()) {
+			ob_end_flush();
+		}
 
 		$colour = ($result->failureCount() + $result->errorCount() > 0 ? "red" : "green");
 		echo "</ul>\n";


### PR DESCRIPTION
## Overview
This PR fixes a potential PHP Notice that could occur in the test suite HTML reporter when there is no output buffer to flush.

## Changes
- Modified `lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php`
  - Added a condition to check if output buffer exists before calling `ob_end_flush()`
  - Prevents "ob_end_flush(): failed to delete buffer. No buffer to delete" notice

## Impact
- Improves test suite reliability by preventing unnecessary PHP notices
- No functional changes to the test reporting behavior