### PR TITLE
Improve PHPDoc and Code Comments for PHP 8 Compatibility

### DIFF
--- a/lib/Cake/Controller/Component/FlashComponent.php
+++ b/lib/Cake/Controller/Component/FlashComponent.php
@@ -26,6 +26,9 @@ App::uses('CakeSession', 'Model/Datasource');
  * FlashHelper.
  *
  * @package       Cake.Controller.Component
+ * @method error(string $string)
+ * @method success(string $string)
+ * @method warning(string $string)
  */
 class FlashComponent extends Component {
 

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -204,8 +204,8 @@ class ErrorHandler {
  * @return bool true if error was handled
  */
 	public static function handleError($code, $description, $file = null, $line = null, $context = null) {
-		//PHP8 migration guide: https://www.php.net/manual/en/migration80.incompatible.php
-		//See: @ operator
+		// PHP8 migration guide: https://www.php.net/manual/en/migration80.incompatible.php
+		// See: @ operator
 		if (!(error_reporting() & $code)) {
 			return false;
 		}

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -361,7 +361,7 @@ class Mysql extends DboSource {
 				$fields[$column->Field]['unsigned'] = $this->_unsigned($column->Type);
 			}
 			if (in_array($fields[$column->Field]['type'], array('timestamp', 'datetime')) &&
-				//Falling back to default empty string due to PHP8.1 deprecation notice.
+				// Falling back to default empty string due to PHP8.1 deprecation notice.
 				in_array(strtoupper($column->Default ?? ""), array('CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP()'))
 			) {
 				$fields[$column->Field]['default'] = null;
@@ -384,7 +384,7 @@ class Mysql extends DboSource {
 		$this->_cacheDescription($key, $fields);
 		$cols->closeCursor();
 
-		//Fields must be an array for compatibility with PHP8.1 (deprecation notice) but also let's keep backwards compatibility for method.
+		// Fields must be an array for compatibility with PHP8.1 (deprecation notice) but also let's keep backwards compatibility for method.
 		if (count($fields) === 0) {
 			return false;
 		}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2072,7 +2072,7 @@ class DboSource extends DataSource {
  * @return string
  */
 	public function renderJoinStatement($data) {
-		//Fixed deprecation notice in PHP8.1 - fallback to empty string
+		// Fixed deprecation notice in PHP8.1 - fallback to empty string
 		if (strtoupper($data['type'] ?? "") === 'CROSS' || empty($data['conditions'])) {
 			return "{$data['type']} JOIN {$data['table']} {$data['alias']}";
 		}

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -330,8 +330,8 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * This is a wrapper for ArrayAccess. Use setRule() directly for
  * chainable access.
  *
- * @param string $index Name of the rule.
- * @param CakeValidationRule|array $rule Rule to add to $index.
+ * @param mixed $index Name of the rule.
+ * @param mixed|CakeValidationRule|array $rule Rule to add to $index.
  * @return void
  * @see http://www.php.net/manual/en/arrayobject.offsetset.php
  */
@@ -342,7 +342,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
 /**
  * Unsets a validation rule
  *
- * @param string $index name of the rule
+ * @param mixed $index name of the rule
  * @return void
  */
 	public function offsetUnset(mixed $index) : void {

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -1156,7 +1156,7 @@ class CakeRequest implements ArrayAccess {
 /**
  * Array access unset() implementation
  *
- * @param string $name Name to unset.
+ * @param mixed $name Name to unset.
  * @return void
  */
 	public function offsetUnset(mixed $name) : void {

--- a/lib/Cake/Network/Http/HttpSocketResponse.php
+++ b/lib/Cake/Network/Http/HttpSocketResponse.php
@@ -443,7 +443,7 @@ class HttpSocketResponse implements ArrayAccess {
 /**
  * ArrayAccess - Offset Unset
  *
- * @param string $offset Offset to unset.
+ * @param mixed $offset Offset to unset.
  * @return void
  */
 	public function offsetUnset(mixed $offset) : void {

--- a/lib/Cake/Test/Case/AllControllerTest.php
+++ b/lib/Cake/Test/Case/AllControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AllControllersTest file
+ * AllControllerTest file
  *
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -17,7 +17,7 @@
  */
 
 /**
- * AllControllersTest class
+ * AllControllerTest class
  *
  * This test group will run Controller related tests.
  *

--- a/lib/Cake/Test/Case/AllI18nTest.php
+++ b/lib/Cake/Test/Case/AllI18nTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AllLocalizationTest file
+ * AllI18nTest file
  *
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
@@ -17,7 +17,7 @@
  */
 
 /**
- * AllLocalizationTest class
+ * AllI18nTest class
  *
  * This test group will run i18n/l10n tests
  *


### PR DESCRIPTION
## Overview
This PR improves PHPDoc annotations and code comments throughout the codebase to better align with PHP 8 standards and improve IDE support.

## Changes
### PHPDoc Improvements
- Added method annotations for FlashComponent (`@method` tags for error, success, warning)
- Updated parameter types in various classes to use `mixed` type for PHP 8 compatibility:
  - CakeValidationSet
  - CakeRequest
  - HttpSocketResponse

### Code Comment Improvements
- Standardized comment formatting (added spaces after //)
- Clarified PHP 8.1 deprecation notice comments
- Fixed test case file header comments to match class names:
  - AllControllerTest
  - AllI18nTest

## Impact
- Better IDE support through improved PHPDoc annotations
- Clearer code documentation
- No functional changes to the codebase