### PR TITLE
Update version bump workflow to start from 1.0.0

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,6 +14,8 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          custom_tag: 1.0.0
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Changes

Updated the version bump workflow configuration to:
- Set initial version to 1.0.0
- Configure patch as default bump type

## Purpose
- Establish proper semantic versioning starting from 1.0.0
- Ensure consistent version increments with patch as default