### PR TITLE
Bump PHPUnit to ^9.6.33 to fix CVE-2026-24765 (Dependabot alert #3)

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -22,9 +22,6 @@
 		"ext-mcrypt": "*",
 		"cakephp/cakephp": "~2.9"
 	},
-	"require-dev": {
-		"phpunit/phpunit": "^9.6.33"
-	},
 	"suggest": {
 		"cakephp/cakephp-codesniffer": "Easily check code formatting against the CakePHP coding standards."
 	},

--- a/app/composer.json
+++ b/app/composer.json
@@ -23,7 +23,7 @@
 		"cakephp/cakephp": "~2.9"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "3.7.*"
+		"phpunit/phpunit": "^9.6.33"
 	},
 	"suggest": {
 		"cakephp/cakephp-codesniffer": "Easily check code formatting against the CakePHP coding standards."

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,19 @@
 		"ext-intl": "Required to use IntlDateFormatter instead of strftime, if not Symfony polyfill will be used."
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9.5",
+		"phpunit/phpunit": "^9.6.33",
 		"cakephp/cakephp-codesniffer": "^1.0.0"
 	},
 	"config": {
 		"vendor-dir": "vendors/",
-		"process-timeout": 0
+		"process-timeout": 0,
+		"policy": {
+			"advisories": {
+				"ignore": {
+					"squizlabs/php_codesniffer": "Pinned to 1.x by cakephp-codesniffer 1.x (CakePHP2 coding standard); dev-only tool, never shipped to production. The 1.x line is frozen upstream, so its advisories are accepted."
+				}
+			}
+		}
 	},
 	"bin": [
 		"lib/Cake/Console/cake"

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,15 @@
 		"process-timeout": 0,
 		"policy": {
 			"advisories": {
-				"ignore": {
-					"squizlabs/php_codesniffer": "Pinned to 1.x by cakephp-codesniffer 1.x (CakePHP2 coding standard); dev-only tool, never shipped to production. The 1.x line is frozen upstream, so its advisories are accepted."
+				"ignore-id": {
+					"PKSA-6vdd-n4sx-knhy": {
+						"on-audit": false,
+						"reason": "phpcs 1.x arbitrary shell execution (GHSA-mhfv-8rc9-w38c). squizlabs/php_codesniffer is pinned to 1.x by cakephp-codesniffer 1.x (CakePHP2 coding standard), a dev-only tool never shipped to production. Unblocks install only; still reported by composer audit. Temporary exception until a fix is backported."
+					},
+					"CVE-2026-67434": {
+						"on-audit": false,
+						"reason": "phpcs OS command injection (PKSA-rdkp-vv9z-mjkg / GHSA-hmqg-cxww-wqhq). Same rationale as PKSA-6vdd-n4sx-knhy."
+					}
 				}
 			}
 		}

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -1844,6 +1844,7 @@ class HttpSocketTest extends CakeTestCase {
 			$this->markTestSkipped('Found valid certificate, was expecting invalid certificate.');
 		} catch (SocketException $e) {
 			$message = $e->getMessage();
+			$this->skipIf(strpos($message, 'php_network_getaddresses') !== false, 'Test host could not be resolved, skipping.');
 			$this->skipIf(strpos($message, 'Invalid HTTP') !== false, 'Invalid HTTP Response received, skipping.');
 			$this->assertStringContainsString('Failed to enable crypto', $message);
 		}

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -1832,21 +1832,50 @@ class HttpSocketTest extends CakeTestCase {
 	}
 
 /**
- * Test that requests fail when peer verification fails.
+ * Test that requests fail when peer verification fails, using a local TLS server with a self-signed certificate.
  *
  * @return void
  */
 	public function testVerifyPeer() {
 		$this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
-		$socket = new HttpSocket();
+		$this->skipIf(!function_exists('proc_open'), 'proc_open is not available, cannot start the TLS fixture server.');
+
+		$descriptorSpec = array(
+			1 => array('pipe', 'w'),
+			2 => array('pipe', 'w'),
+		);
+		$process = proc_open(
+			PHP_BINARY . ' ' . escapeshellarg(CAKE . 'Test' . DS . 'test_app' . DS . 'tls_server.php'),
+			$descriptorSpec,
+			$pipes
+		);
+		if (!is_resource($process)) {
+			$this->markTestSkipped('Unable to start the TLS fixture server.');
+		}
+
+		stream_set_timeout($pipes[1], 10);
+		$port = trim((string)fgets($pipes[1]));
+		if (!is_numeric($port)) {
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+			proc_terminate($process);
+			proc_close($process);
+			$this->markTestSkipped('TLS fixture server did not start.');
+		}
+
 		try {
-			$socket->get('https://tv.eurosport.com/');
-			$this->markTestSkipped('Found valid certificate, was expecting invalid certificate.');
-		} catch (SocketException $e) {
-			$message = $e->getMessage();
-			$this->skipIf(strpos($message, 'php_network_getaddresses') !== false, 'Test host could not be resolved, skipping.');
-			$this->skipIf(strpos($message, 'Invalid HTTP') !== false, 'Invalid HTTP Response received, skipping.');
-			$this->assertStringContainsString('Failed to enable crypto', $message);
+			$socket = new HttpSocket(array('timeout' => 10));
+			try {
+				$socket->get('https://127.0.0.1:' . $port . '/');
+				$this->fail('Peer verification must reject the self-signed certificate, but the request succeeded.');
+			} catch (SocketException $e) {
+				$this->assertStringContainsString('Failed to enable crypto', $e->getMessage());
+			}
+		} finally {
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+			proc_terminate($process);
+			proc_close($process);
 		}
 	}
 

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -1844,39 +1844,95 @@ class HttpSocketTest extends CakeTestCase {
 			1 => array('pipe', 'w'),
 			2 => array('pipe', 'w'),
 		);
-		$process = proc_open(
-			PHP_BINARY . ' ' . escapeshellarg(CAKE . 'Test' . DS . 'test_app' . DS . 'tls_server.php'),
-			$descriptorSpec,
-			$pipes
-		);
-		if (!is_resource($process)) {
-			$this->markTestSkipped('Unable to start the TLS fixture server.');
-		}
-
-		stream_set_timeout($pipes[1], 10);
-		$port = trim((string)fgets($pipes[1]));
-		if (!is_numeric($port)) {
-			fclose($pipes[1]);
-			fclose($pipes[2]);
-			proc_terminate($process);
-			proc_close($process);
-			$this->markTestSkipped('TLS fixture server did not start.');
-		}
+		$process = null;
+		$pipes = array();
+		$configFile = null;
+		$pemFile = null;
+		$fixtureInteractionsComplete = false;
+		$processExitCode = null;
 
 		try {
+			$configFile = tempnam(sys_get_temp_dir(), 'cake_tls_config_');
+			$pemFile = tempnam(sys_get_temp_dir(), 'cake_tls_');
+			if ($configFile === false || $pemFile === false) {
+				$this->fail('Unable to create the TLS fixture temporary files.');
+			}
+
+			$process = proc_open(
+				array(
+					PHP_BINARY,
+					CAKE . 'Test' . DS . 'test_app' . DS . 'tls_server.php',
+					$configFile,
+					$pemFile,
+				),
+				$descriptorSpec,
+				$pipes
+			);
+			if (!is_resource($process)) {
+				$this->fail('Unable to start the TLS fixture server.');
+			}
+
+			stream_set_timeout($pipes[1], 10);
+			stream_set_blocking($pipes[2], false);
+			$fixture = json_decode(trim((string)fgets($pipes[1])), true);
+			if (!is_array($fixture) || !isset($fixture['port'])) {
+				$stderr = trim((string)stream_get_contents($pipes[2]));
+				$message = 'TLS fixture server did not start.';
+				if ($stderr !== '') {
+					$message .= ' ' . $stderr;
+				}
+				$this->fail($message);
+			}
+
+			$port = (int)$fixture['port'];
+			clearstatcache(true, $pemFile);
+			if ($port < 1 || $port > 65535 || !is_file($pemFile) || filesize($pemFile) < 1) {
+				$this->fail('TLS fixture server returned invalid startup information.');
+			}
+
+			$url = 'https://127.0.0.1:' . $port . '/';
+			$allowSelfSignedSocket = new HttpSocket(array(
+				'timeout' => 10,
+				'ssl_allow_self_signed' => true,
+			));
+			$response = $allowSelfSignedSocket->get($url);
+			$this->assertEquals(200, $response->code, 'The TLS fixture certificate must be valid for 127.0.0.1.');
+
 			$socket = new HttpSocket(array('timeout' => 10));
 			try {
-				$socket->get('https://127.0.0.1:' . $port . '/');
+				$socket->get($url);
 				$this->fail('Peer verification must reject the self-signed certificate, but the request succeeded.');
 			} catch (SocketException $e) {
 				$this->assertStringContainsString('Failed to enable crypto', $e->getMessage());
 			}
+			$fixtureInteractionsComplete = true;
 		} finally {
-			fclose($pipes[1]);
-			fclose($pipes[2]);
-			proc_terminate($process);
-			proc_close($process);
+			foreach ($pipes as $pipe) {
+				if (is_resource($pipe)) {
+					fclose($pipe);
+				}
+			}
+			if (is_resource($process)) {
+				if (!$fixtureInteractionsComplete) {
+					proc_terminate($process);
+				}
+				$processExitCode = proc_close($process);
+			}
+			foreach (array($configFile, $pemFile) as $temporaryFile) {
+				if (is_string($temporaryFile)) {
+					clearstatcache(true, $temporaryFile);
+					if (is_file($temporaryFile)) {
+						@unlink($temporaryFile);
+					}
+				}
+			}
 		}
+
+		$this->assertEquals(0, $processExitCode, 'TLS fixture server exited with an error.');
+		clearstatcache(true, $configFile);
+		$this->assertFalse(is_file($configFile), 'TLS fixture OpenSSL config file was not removed.');
+		clearstatcache(true, $pemFile);
+		$this->assertFalse(is_file($pemFile), 'TLS fixture certificate file was not removed.');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -86,7 +86,7 @@ class DebuggerTest extends CakeTestCase {
 		$this->assertTrue(is_array($result));
 		$this->assertEquals(4, count($result));
 
-		$pattern = '/<code>.*?<span style\="color\: \#\d+">.*?&lt;\?php/';
+		$pattern = '/<code(?:\s[^>]*)?>.*?<span style="color: #[0-9A-Fa-f]{6}">.*?&lt;\?php/';
 		$this->assertMatchesRegularExpression($pattern, $result[0]);
 
 		$result = Debugger::excerpt(__FILE__, 11, 2);

--- a/lib/Cake/Test/test_app/tls_server.php
+++ b/lib/Cake/Test/test_app/tls_server.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * TLS server fixture
+ *
+ * Helper for HttpSocketTest::testVerifyPeer(). Starts a TLS server on
+ * 127.0.0.1 using a runtime-generated self-signed certificate, so that
+ * peer verification deterministically fails when a client connects to it.
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @package       Cake.Test.TestApp
+ * @since         CakePHP(tm) v 2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+$pkey = openssl_pkey_new(array(
+	'private_key_bits' => 2048,
+	'private_key_type' => OPENSSL_KEYTYPE_RSA,
+));
+$csr = openssl_csr_new(array('commonName' => 'localhost'), $pkey);
+$cert = openssl_csr_sign($csr, null, $pkey, 1, array('digest_alg' => 'sha256'));
+
+openssl_x509_export($cert, $certPem);
+openssl_pkey_export($pkey, $keyPem);
+
+$pemFile = tempnam(sys_get_temp_dir(), 'cake_tls_');
+file_put_contents($pemFile, $certPem . $keyPem);
+
+$context = stream_context_create(array(
+	'ssl' => array(
+		'local_cert' => $pemFile,
+	),
+));
+$server = @stream_socket_server(
+	'tls://127.0.0.1:0',
+	$errNo,
+	$errStr,
+	STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
+	$context
+);
+if ($server === false) {
+	unlink($pemFile);
+	fwrite(STDERR, $errStr . "\n");
+	exit(1);
+}
+
+$name = stream_socket_get_name($server, false);
+$port = substr($name, strrpos($name, ':') + 1);
+fwrite(STDOUT, $port . "\n");
+fflush(STDOUT);
+
+$conn = @stream_socket_accept($server, 10);
+if (is_resource($conn)) {
+	fclose($conn);
+}
+
+unlink($pemFile);
+exit(0);

--- a/lib/Cake/Test/test_app/tls_server.php
+++ b/lib/Cake/Test/test_app/tls_server.php
@@ -20,46 +20,132 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
-$pkey = openssl_pkey_new(array(
-	'private_key_bits' => 2048,
-	'private_key_type' => OPENSSL_KEYTYPE_RSA,
-));
-$csr = openssl_csr_new(array('commonName' => 'localhost'), $pkey);
-$cert = openssl_csr_sign($csr, null, $pkey, 1, array('digest_alg' => 'sha256'));
+$server = null;
+$exitCode = 0;
 
-openssl_x509_export($cert, $certPem);
-openssl_pkey_export($pkey, $keyPem);
+try {
+	if (!isset($argv[1], $argv[2])) {
+		throw new RuntimeException('TLS fixture temporary file paths were not provided.');
+	}
+	$configFile = $argv[1];
+	$pemFile = $argv[2];
 
-$pemFile = tempnam(sys_get_temp_dir(), 'cake_tls_');
-file_put_contents($pemFile, $certPem . $keyPem);
+	$config = "[ req ]\n" .
+		"distinguished_name = req_distinguished_name\n" .
+		"req_extensions = v3_req\n" .
+		"prompt = no\n" .
+		"\n" .
+		"[ req_distinguished_name ]\n" .
+		"CN = 127.0.0.1\n" .
+		"\n" .
+		"[ v3_req ]\n" .
+		"basicConstraints = CA:FALSE\n" .
+		"keyUsage = critical, digitalSignature, keyEncipherment\n" .
+		"extendedKeyUsage = serverAuth\n" .
+		"subjectAltName = IP:127.0.0.1\n";
+	if (file_put_contents($configFile, $config) === false) {
+		throw new RuntimeException('Unable to write the TLS fixture OpenSSL config file.');
+	}
 
-$context = stream_context_create(array(
-	'ssl' => array(
-		'local_cert' => $pemFile,
-	),
-));
-$server = @stream_socket_server(
-	'tls://127.0.0.1:0',
-	$errNo,
-	$errStr,
-	STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
-	$context
-);
-if ($server === false) {
-	unlink($pemFile);
-	fwrite(STDERR, $errStr . "\n");
-	exit(1);
+	$pkey = openssl_pkey_new(array(
+		'config' => $configFile,
+		'private_key_bits' => 2048,
+		'private_key_type' => OPENSSL_KEYTYPE_RSA,
+	));
+	if ($pkey === false) {
+		throw new RuntimeException('Unable to generate the TLS fixture private key.');
+	}
+
+	$csr = openssl_csr_new(
+		array('commonName' => '127.0.0.1'),
+		$pkey,
+		array(
+			'config' => $configFile,
+			'digest_alg' => 'sha256',
+			'req_extensions' => 'v3_req',
+		)
+	);
+	if ($csr === false) {
+		throw new RuntimeException('Unable to generate the TLS fixture certificate request.');
+	}
+
+	$cert = openssl_csr_sign(
+		$csr,
+		null,
+		$pkey,
+		1,
+		array(
+			'config' => $configFile,
+			'digest_alg' => 'sha256',
+			'x509_extensions' => 'v3_req',
+		)
+	);
+	if ($cert === false) {
+		throw new RuntimeException('Unable to sign the TLS fixture certificate.');
+	}
+
+	if (!openssl_x509_export($cert, $certPem) || !openssl_pkey_export($pkey, $keyPem)) {
+		throw new RuntimeException('Unable to export the TLS fixture certificate.');
+	}
+
+	if (file_put_contents($pemFile, $certPem . $keyPem) === false) {
+		throw new RuntimeException('Unable to write the TLS fixture certificate.');
+	}
+
+	$context = stream_context_create(array(
+		'ssl' => array(
+			'local_cert' => $pemFile,
+		),
+	));
+	$server = @stream_socket_server(
+		'tls://127.0.0.1:0',
+		$errNo,
+		$errStr,
+		STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
+		$context
+	);
+	if ($server === false) {
+		throw new RuntimeException('Unable to start the TLS fixture server: ' . $errStr);
+	}
+
+	$name = stream_socket_get_name($server, false);
+	if ($name === false) {
+		throw new RuntimeException('Unable to read the TLS fixture server address.');
+	}
+	$port = substr($name, strrpos($name, ':') + 1);
+	$startupInfo = json_encode(array(
+		'port' => (int)$port,
+	));
+	if ($startupInfo === false) {
+		throw new RuntimeException('Unable to encode the TLS fixture startup information.');
+	}
+	fwrite(STDOUT, $startupInfo . "\n");
+	fflush(STDOUT);
+
+	for ($i = 0; $i < 2; $i++) {
+		$conn = @stream_socket_accept($server, 10);
+		if (is_resource($conn)) {
+			stream_set_timeout($conn, 10);
+			$request = '';
+			while (!feof($conn) && strpos($request, "\r\n\r\n") === false) {
+				$chunk = fread($conn, 1024);
+				if ($chunk === false) {
+					break;
+				}
+				$request .= $chunk;
+			}
+			fwrite($conn, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+			fflush($conn);
+			fclose($conn);
+		}
+	}
+} catch (Throwable $e) {
+	fwrite(STDERR, $e->getMessage() . "\n");
+	$exitCode = 1;
+} finally {
+	if (is_resource($server)) {
+		fclose($server);
+	}
 }
 
-$name = stream_socket_get_name($server, false);
-$port = substr($name, strrpos($name, ':') + 1);
-fwrite(STDOUT, $port . "\n");
-fflush(STDOUT);
-
-$conn = @stream_socket_accept($server, 10);
-if (is_resource($conn)) {
-	fclose($conn);
-}
-
-unlink($pemFile);
-exit(0);
+exit($exitCode);


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #3: https://github.com/basi/cakephp2-php8/security/dependabot/3

- **CVE-2026-24765 / [GHSA-vvj3-c3rp-c85p](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p)** (severity: high, CVSS 7.8, CWE-502): PHPUnit's PHPT code-coverage handling (`cleanupForCoverage()`) deserializes `.coverage` files via `unserialize` without an `allowed_classes` restriction. Patched in 9.6.33 (latest 9.6.x is 9.6.36).

This repository contains no `*.phpt` tests and CI collects no coverage, so there is no actual attack surface here — the manifest changes below are what resolve the alert. The PR additionally un-breaks CI (every `composer install` had been failing since Nov 2025) and restores real TLS peer-verification test coverage. Updated after a code review (3 findings addressed — see "Review response" below), then brought up to date with `main` (#23 switched the CI matrix from PHP 8.2 to 8.4), which required one PHP 8.4 test-expectation fix.

## Changes

1. **`app/composer.json`**: remove `phpunit/phpunit` from `require-dev` (previously `3.7.*`, the constraint the alert fired on)
   - The app skeleton pins upstream `cakephp/cakephp ~2.9` and `php >= 5.3.0`; any modern PHPUnit constraint there would be self-contradictory (upstream 2.x `CakeTestCase` extends the PHPUnit 3 era `PHPUnit_Framework_TestCase`, and PHPUnit 9.6 requires PHP >= 7.3). The skeleton is not exercised by CI nor by the documented consumption path (README instructs the VCS-repository method), so the dev dependency is vestigial. Removing it resolves the alert without advertising an impossible install
2. **`composer.json`**: `phpunit/phpunit` `^9.5` → `^9.6.33` — raises the floor to the first patched version (a fresh install resolves to 9.6.36)
3. **`composer.json`**: ID-scoped advisory policy to un-break CI. Since Composer 2.9, resolution of advisory-affected packages is blocked by default, and `cakephp/cakephp-codesniffer ^1.0.0` → `squizlabs/php_codesniffer ^1.4` made **every CI `composer install` fail since Nov 2025** (#19, #20). `config.policy.advisories.ignore-id` now lists exactly the two blocking advisories — `PKSA-6vdd-n4sx-knhy` (phpcs 1.x arbitrary shell execution, GHSA-mhfv-8rc9-w38c) and `CVE-2026-67434` (phpcs OS command injection, PKSA-rdkp-vv9z-mjkg / GHSA-hmqg-cxww-wqhq) — each with `"on-audit": false` and a reason, so **only install/update blocking is lifted while `composer audit` and the post-install warning keep reporting both advisories**
   - Note on `on-audit` semantics: Composer's `06-config.md` prose currently describes `on-block`/`on-audit` inverted relative to the implementation. The actual behavior (per `AdvisoriesPolicyConfig::getIgnoreIdForOperation()` in 2.10.2 and verified empirically) is that the flags scope *where the ignore applies*: `"on-audit": false` = ignored for blocking, still reported by audit
4. **`lib/Cake/Test/Case/Network/Http/HttpSocketTest.php`** + new **`lib/Cake/Test/test_app/tls_server.php`**: `testVerifyPeer` now verifies TLS peer rejection against a **local TLS server with a runtime-generated self-signed certificate** instead of a dead external host
   - The previous target `tv.eurosport.com` no longer resolves, which had left the test permanently skipped (no regression coverage for peer verification). Nothing is committed to the repository and nothing can expire: the helper generates a throwaway certificate at runtime — CN=127.0.0.1 with `subjectAltName = IP:127.0.0.1`, `serverAuth` EKU and `CA:FALSE`, built from an explicit OpenSSL config so the fixture does not depend on a system `openssl.cnf`
   - The test owns the temporary files (OpenSSL config + PEM) and passes their paths to the child over argv (array-form `proc_open`, no shell escaping); startup is handed back as a JSON line, and the child's stderr is folded into the failure message. Fixture startup problems are test **failures**, not skips, so environment rot stays visible
   - The assertion is two-sided: a positive control with `ssl_allow_self_signed => true` must receive an HTTP 200 from the fixture first (proving the server and certificate genuinely work for 127.0.0.1), then the default-configuration client must be rejected with `Failed to enable crypto`. The child serves both connections with real HTTP responses, and its exit code 0 and the removal of both temporary files are asserted as well
5. **`lib/Cake/Test/Case/Utility/DebuggerTest.php`**: update the expected `highlight_string()` pattern for PHP 8.4 (the `<code>` element may carry attributes and colors are emitted as 6-digit hex). Needed because the CI matrix now includes PHP 8.4 (see #23)

## Verification

- Manifest validity: `composer validate` passes for both root and `app/` (Composer 2.10.2)
- Clean resolution without a lock file (replicating CI): `phpunit/phpunit` → 9.6.36, `squizlabs/php_codesniffer` → 1.5.6, zero problems, exit 0
- Advisory visibility preserved: post-install prints `Found 2 security vulnerability advisories affecting 1 package.` and `composer audit` lists both advisories in full — only the install-time block is lifted
- CI on the current head (with `main` merged in, matrix PHP 8.0 × mysql/pgsql/sqlite + PHP 8.4 × mysql): **all 4 jobs pass** — [run 32952486089](https://github.com/basi/cakephp2-php8/actions/runs/32952486089). The hardened `testVerifyPeer` runs its assertions (not skipped) on every job
- The initial, pre-hardening fixture was also verified locally on PHP 8.0.30/8.2.33 (Docker, sqlite) before the follow-up strengthened it

## Review response

| Finding | Resolution |
| --- | --- |
| [High] `app/composer.json` deps incompatible with PHPUnit 9 and unverified by CI | Removed the vestigial `phpunit/phpunit` dev dependency from the skeleton (option 1 of the review); the skeleton reverts to a coherent legacy snapshot |
| [High] Package-wide advisory ignore hides current and future phpcs advisories | Replaced with `ignore-id` entries for exactly the two blocking advisories, scoped to lift blocking only; `composer audit` keeps reporting them. Backporting a phpcs fix / migrating the ruleset remains a separate task |
| [Medium] `testVerifyPeer` permanently skipped | Replaced the dead external host with a local self-signed TLS fixture; a follow-up hardened it (SAN certificate from an explicit OpenSSL config, positive control via `ssl_allow_self_signed`, child stderr/exit-code propagation, fixture problems fail instead of skip) |

## Out of scope (known separate issues)

- **Dependabot alert #6** (`cakephp/cakephp ~2.9` in `app/composer.json`, GHSA-wpvj-hjcr-h3p2): the view path traversal itself is being backported in #22 (draft); note that the backport alone does not close the manifest-based alert — the `cakephp/cakephp ~2.9` requirement will still need to be removed/adjusted or the alert dismissed
- `bump-version.yml` duplicate-tag failure (`custom_tag: 1.1.0` already exists): the update to 1.2.0 is staged in #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)