### PR TITLE
Run CI tests on PHP 8.4 instead of 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
             db-type: pgsql
           - php-version: '8.0'
             db-type: sqlite
-          - php-version: '8.2'
+          - php-version: '8.4'
             db-type: mysql
 
     services:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here are steps I took to migrate my project through all versions to PHP 8.1, may
 
 ## Before using this fork ⚠️
 
-- ~~Tests of CakePHP framework aren't refactored yet to support PHP 8. Main issue is old version of PHPUnit that is tightly coupled to framework's tests. Issue for fixing this situation is here: https://github.com/kamilwylegala/cakephp2-php8/issues/7~~ Framework tests are migrated to PHPUnit 9.*. Github actions are running tests on PHP 8.0, 8.1.
+- ~~Tests of CakePHP framework aren't refactored yet to support PHP 8. Main issue is old version of PHPUnit that is tightly coupled to framework's tests. Issue for fixing this situation is here: https://github.com/kamilwylegala/cakephp2-php8/issues/7~~ Framework tests are migrated to PHPUnit 9.*. Github actions are running tests on PHP 8.0, 8.4.
 - ~~Due to lack of tests ☝️~~ - **you also need to rely** on tests in your application after integrating with this fork.
 - If after integration you spot any issues related to framework please let me know by creating an issue or pull request with fix.
 


### PR DESCRIPTION
## Summary

Update the CI test matrix to run on PHP 8.4 instead of PHP 8.2.

The codebase already ships PHP 8.4 fixes (changelog 2025-02-04, upstream kamilwylegala/cakephp2-php8#83 merged as f9dc42fc2) and downstream consumers run this fork on PHP 8.4 in production, but CI has never actually exercised 8.4 — the highest version in the matrix was 8.2.

## Changes

- **`.github/workflows/tests.yml`**: matrix include `8.2 × mysql` → `8.4 × mysql`. Resulting matrix: `8.0 × (mysql, pgsql, sqlite)` + `8.4 × mysql`.
- **`README.md`**: updated the stale "Github actions are running tests on PHP 8.0, 8.1." note to reflect the new matrix (it was already out of date vs. the actual 8.0/8.2 matrix).

## Verification

- PECL mcrypt 1.0.7+ supports PHP 8.4 (1.0.9 supports up to 8.6), so the `setup-php` extensions step (`mcrypt` included) installs cleanly on 8.4.
- PHPUnit 9.6's `convertDeprecationsToExceptions` defaults to `false`, so new PHP 8.4 deprecation notices do not fail the suite.
- On this PR, the `Install PHP with extensions` step runs before Composer and validates the PHP 8.4 toolchain immediately; full test verification is blocked by the pre-existing Composer failure below.

## Known CI status

- All matrix cells currently fail at `Install Composer Packages` due to the Composer >= 2.9 security-advisory policy (broken on `main` since Nov 2025, unrelated to this change — the fix lives in #21). Once #21 merges, re-running this PR's workflow will execute the full suite; no rebase is needed because PR CI runs on the merge ref.
- `custom_tag` in `bump-version.yml` is intentionally untouched: 1.2.0 is reserved by #22 and a CI-only change needs no release. The resulting duplicate-tag failure of the Bump version workflow on merge is known and harmless (same as the #18 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
